### PR TITLE
AbsoluteEncoder.java: Removed simulation code, fixed frame of ref, improved documentation.

### DIFF
--- a/src/main/java/frc/robot/AbsoluteEncoder.java
+++ b/src/main/java/frc/robot/AbsoluteEncoder.java
@@ -13,98 +13,45 @@ import edu.wpi.first.wpilibj.simulation.AnalogInputSim;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 /**
- * Add your docs here.
+ * Our wrapper for the absolute encoder, such as the US Digital MA3.  
+ * Most useful for tracking the position of swerve wheels.
  */
 public class AbsoluteEncoder {
-    private AnalogInput analogIn;
-    private AnalogInputSim analogInSim;
-    private boolean isInverted;
+    private AnalogInput m_analogIn;
+    private boolean m_isInverted;
 
-    private double voltageToRadians = Math.PI * 2 / 5;
+    private double VOLTAGE_TO_RADIANS = Math.PI * 2 / 5;
 
     private double m_offset;
-    private int polarity;
 
     /**
      * Construct and absolute encoder, most likely a US Digital MA3 encoder.
      * 
      * @param channel  analog in (sometimes also refered to as AIO) port on the
      *                 roboRIO
-     * @param inverted set this to <i>TRUE</i> if physically turning the wheel
+     * @param inverted set this to <i>TRUE</i> if physically turning the swerve wheel
      *                 <i>CLOCKWISE</i> (looking down on it from the top of the bot)
-     *                 <i>INCREASES</i> the voltage it returns
-     * @param offset   swerve offset (in <i>DEGREES</i>), like we've been using for
-     *                 the past three years. This value is <i>SUBTRACTED</i> from
-     *                 the output.
+     *                 <i>INCREASES</i> the raw voltage the encoder returns.
+     * @param offset   swerve offset (in <i>RADIANS</i>). This value is <i>SUBTRACTED</i> from
+     *                 the raw encoder output, so double check your algebra!
      */
     public AbsoluteEncoder(int channel, boolean inverted, double offset) {
-        analogIn = new AnalogInput(channel);
-        analogInSim = new AnalogInputSim(analogIn);
-        analogInSim.setVoltage(0);
-        isInverted = inverted;
+        m_analogIn = new AnalogInput(channel);
+        m_isInverted = inverted;
         m_offset = offset;
-        polarity = isInverted ? -1 : 1;
-        
-    }
-
-    /**
-     * Does some fancy mafs (mathematics) to figure out the value that the simulated
-     * absolute encoder should be at. Read comments in source code below.
-     * 
-     * @param turnVoltage voltage that will go to the turning motor, range: [-1, 1]
-     */
-    public void sendVoltage(double turnVoltage) {
-
-        // gear ratio between motor and wheel / encoder
-        double gearRatio = 12.8;
-
-        // maximum RPM for motor under 0 load
-        double motorRPM = 5500;
-
-        // how long it takes to run one loop of the periodic (in seconds)
-        double tickPeriod = Robot.kDefaultPeriod;
-
-        if (turnVoltage > 1) {
-            turnVoltage = 1;
-        } else if (turnVoltage < -1) {
-            turnVoltage = -1;
-        }
-
-        // started with motorRPM and converted to wheel rotations per tick
-        // RPM * (min / sec) * (s / tick) * (wheel rotations / motor rotations)
-        double wheelRotationsPerTick = motorRPM / 60 * tickPeriod / gearRatio; // 0.143
-        double wheelRotationsSinceLastTick = wheelRotationsPerTick * turnVoltage;
-        double voltsSinceLastTick = 5 * wheelRotationsSinceLastTick;
-        voltsSinceLastTick *= polarity;
-
-        double outputVoltage = analogIn.getVoltage() + voltsSinceLastTick;
-
-        SmartDashboard.putNumber("turning voltage" + analogIn.getChannel(), turnVoltage);
-
-        // convert output to a number between 0 and 5
-        outputVoltage = (((outputVoltage % 5) + 5) % 5);
-
-        // basically this "hijacks" the simulated absolute encoder to say that it's
-        // reading the voltage that u give it, range: [0, 5]
-        analogInSim.setVoltage(outputVoltage);
-
     }
 
     /**
      * 
-     * @return the position of the as a Rotation2d. zero points toward the front
-     *         of the bot. the value increases as the swerve wheel is turned
-     *         clockwise.
+     * @return the angle of the absolute encoder, as a Rotation2d object. zero points toward the front
+     *         of the bot. <i>the value increases as the swerve wheel is turned counter-clockwise.</i>
      */
     
     public Rotation2d getAngle() {
         if (isInverted) {
-
-            return new Rotation2d((5 - analogIn.getVoltage() ) * voltageToRadians - m_offset);
+            return new Rotation2d((5 - analogIn.getVoltage()) * VOLTAGE_TO_RADIANS - m_offset);
         }
 
-        return new Rotation2d((analogIn.getVoltage() ) * voltageToRadians - m_offset);
+        return new Rotation2d((analogIn.getVoltage() ) * VOLTAGE_TO_RADIANS - m_offset);
     }
 }
-
-// copied from simulatorpractice2021


### PR DESCRIPTION
AbsoluteEncoder.java was directly copied from simulatorPractice2021, which had s
ome issues.
I removed everything referencing the simulator.
Note that I changed the frame of reference for which direction is positive.  Thi
s way, it conforms with the ChassisSpeeds frame of refrence.
Everything is in terms of radians, no degrees.  Improved documentation, it shoul
d be completely accurate now.
Cleaned up the variable names.